### PR TITLE
Fix pip package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Not all endpoints and features are fully supported.
 ## Installation
 
 ```bash
-pip install python-tado
+pip install tadoasync
 ```
 
 ## Usage


### PR DESCRIPTION
# Proposed Changes

I got really confused trying to check this new async lib (found [here](https://github.com/home-assistant/core/pull/121503)).
This repo is named `python-tado` but the pip package is actually `tadoasync`.
Repo of 'original' library is named `PyTado` but published on PyPI as `python-tado`...
Following this readme would have installed the other library.