### PR TITLE
hot water zone compatibility bug fix

### DIFF
--- a/src/tadoasync/models.py
+++ b/src/tadoasync/models.py
@@ -147,7 +147,7 @@ class DazzleMode(DataClassORJSONMixin):
     """DazzleMode model represents the dazzle mode settings of a zone."""
 
     supported: bool
-    enabled: Optional[bool] = field(default=False)
+    enabled: bool = field(default=False)
 
 
 @dataclass

--- a/src/tadoasync/models.py
+++ b/src/tadoasync/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin

--- a/src/tadoasync/models.py
+++ b/src/tadoasync/models.py
@@ -155,7 +155,7 @@ class OpenWindowDetection(DataClassORJSONMixin):
     """OpenWindowDetection model represents the open window detection settings."""
 
     supported: bool
-    enabled: Optional[bool] = field(default=False)
+    enabled: bool = field(default=False)
     timeout_in_seconds: Optional[int] = field(metadata=field_options(alias="timeoutInSeconds"), default=0)
 
 

--- a/src/tadoasync/models.py
+++ b/src/tadoasync/models.py
@@ -156,7 +156,7 @@ class OpenWindowDetection(DataClassORJSONMixin):
 
     supported: bool
     enabled: bool = field(default=False)
-    timeout_in_seconds: Optional[int] = field(metadata=field_options(alias="timeoutInSeconds"), default=0)
+    timeout_in_seconds: int = field(metadata=field_options(alias="timeoutInSeconds"), default=0)
 
 
 @dataclass

--- a/src/tadoasync/models.py
+++ b/src/tadoasync/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
@@ -147,7 +147,7 @@ class DazzleMode(DataClassORJSONMixin):
     """DazzleMode model represents the dazzle mode settings of a zone."""
 
     supported: bool
-    enabled: bool
+    enabled: Optional[bool] = field(default=False)
 
 
 @dataclass
@@ -155,8 +155,8 @@ class OpenWindowDetection(DataClassORJSONMixin):
     """OpenWindowDetection model represents the open window detection settings."""
 
     supported: bool
-    enabled: bool
-    timeout_in_seconds: int = field(metadata=field_options(alias="timeoutInSeconds"))
+    enabled: Optional[bool] = field(default=False)
+    timeout_in_seconds: Optional[int] = field(metadata=field_options(alias="timeoutInSeconds"), default=0)
 
 
 @dataclass


### PR DESCRIPTION
# Proposed Changes
Please see my comments in the HA PR https://github.com/home-assistant/core/pull/121503#issuecomment-2323477115

Due to missing hot water zone attributes(dazzleMode enabled  and open_window_detection enabled  timeout_in_seconds), integration setup flow was failing. I made these local changes to fix the issue. Feel free to let me know if you have a better idea.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
