### PR TITLE
Type child lock method correctly

### DIFF
--- a/src/tadoasync/tadoasync.py
+++ b/src/tadoasync/tadoasync.py
@@ -377,11 +377,8 @@ class Tado:  # pylint: disable=too-many-instance-attributes
         response = await self._request(f"devices/{serial_no}/")
         return Device.from_json(response)
 
-    async def set_child_lock(self, serial_no: str, child_lock: bool | None) -> None:
+    async def set_child_lock(self, serial_no: str, *, child_lock: bool) -> None:
         """Set the child lock."""
-        if not isinstance(child_lock, bool):
-            raise TadoBadRequestError("child_lock must be a boolean")
-
         await self._request(
             f"devices/{serial_no}/childLock",
             data={"childLockEnabled": child_lock},

--- a/tests/test_tado.py
+++ b/tests/test_tado.py
@@ -498,17 +498,6 @@ async def test_set_child_lock(python_tado: Tado, responses: aioresponses) -> Non
     )
     await python_tado.set_child_lock(serial_no=device_id, child_lock=child_lock)
 
-    invalid_child_lock = None
-    responses.put(
-        f"{TADO_API_URL}/devices/{device_id}/childLock",
-        status=204,
-        payload={"childLockEnabled": child_lock},
-    )
-    with pytest.raises(TadoBadRequestError):
-        await python_tado.set_child_lock(
-            serial_no=device_id, child_lock=invalid_child_lock
-        )
-
 
 async def test_add_meter_readings_duplicated(
     python_tado: Tado, responses: aioresponses, snapshot: SnapshotAssertion


### PR DESCRIPTION
Type child lock method correctly. Yes, python is not a typed language, someone could still pass in None, but eigen schuld dikke bult