### PR TITLE
feat: add rate limit tracking and public API

### DIFF
--- a/src/tadoasync/models_v3.py
+++ b/src/tadoasync/models_v3.py
@@ -589,6 +589,8 @@ class ZoneState(DataClassORJSONMixin):  # pylint: disable=too-many-instance-attr
         """Pre deserialize hook."""
         if not d["sensorDataPoints"]:
             d["sensorDataPoints"] = None
+        if d.get("nextTimeBlock") is None:
+            d["nextTimeBlock"] = {}
         return d
 
 

--- a/src/tadoasync/tadoasync.py
+++ b/src/tadoasync/tadoasync.py
@@ -847,17 +847,18 @@ class Tado:  # pylint: disable=too-many-instance-attributes
 
     def _parse_rate_limit(self) -> tuple[int | None, int | None]:
         """Parse rate limit from RateLimit headers."""
-    def extract(pattern: str, value: str) -> int | None:
-        match = re.search(pattern, value)
-        return int(match.group(1)) if match else None
 
-    policy = self._last_headers.get("RateLimit-Policy", "")
-    rl = self._last_headers.get("RateLimit", "")
+        def extract(pattern: str, value: str) -> int | None:
+            match = re.search(pattern, value)
+            return int(match.group(1)) if match else None
 
-    limit = extract(r"quota=(\d+)", policy)
-    remaining = extract(r"remaining=(\d+)", rl)
+        policy = self._last_headers.get("RateLimit-Policy", "")
+        rl = self._last_headers.get("RateLimit", "")
 
-    return limit, remaining
+        limit = extract(r"q=(\d+)", policy)
+        remaining = extract(r"r=(\d+)", rl)
+
+        return limit, remaining
 
     async def __aenter__(self) -> Self:
         """Async enter."""

--- a/src/tadoasync/tadoasync.py
+++ b/src/tadoasync/tadoasync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import enum
 import logging
+import re
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -127,6 +128,10 @@ class Tado:  # pylint: disable=too-many-instance-attributes
         self._device_activation_status = DeviceActivationStatus.NOT_STARTED
         self._expires_at: datetime | None = None
 
+        self._last_headers: dict[str, str] = {}
+        self._last_limit: int | None = None
+        self._last_remaining: int | None = None
+
         _LOGGER.setLevel(logging.DEBUG if debug else logging.INFO)
 
     async def async_init(self) -> None:
@@ -153,6 +158,35 @@ class Tado:  # pylint: disable=too-many-instance-attributes
     def refresh_token(self) -> str | None:
         """Return the refresh token."""
         return self._refresh_token
+
+    @property
+    def session(self) -> ClientSession:
+        """Return the aiohttp session."""
+        return self._ensure_session()
+
+    @property
+    def home_id(self) -> int | None:
+        """Return the home ID."""
+        return self._home_id
+
+    @property
+    def access_token(self) -> str | None:
+        """Return the OAuth access token."""
+        return self._access_token
+
+    async def refresh_auth(self) -> None:
+        """Refresh the OAuth token."""
+        await self._refresh_auth()
+
+    @property
+    def last_headers(self) -> dict[str, str]:
+        """Return headers from the last API response."""
+        return self._last_headers
+
+    @property
+    def rate_limit(self) -> tuple[int | None, int | None]:
+        """Return rate limit (limit, remaining) from the last API response."""
+        return (self._last_limit, self._last_remaining)
 
     async def login_device_flow(self) -> DeviceActivationStatus:
         """Login using device flow."""
@@ -627,6 +661,8 @@ class Tado:  # pylint: disable=too-many-instance-attributes
                 request = await session.request(
                     method=method.value, url=str(url), headers=headers, json=data
                 )
+                self._last_headers = dict(request.headers)
+                self._last_limit, self._last_remaining = self._parse_rate_limit()
                 request.raise_for_status()
         except TimeoutError as err:
             raise TadoConnectionError(
@@ -808,6 +844,23 @@ class Tado:  # pylint: disable=too-many-instance-attributes
             self._session = ClientSession()
             self._close_session = True
         return self._session
+
+    def _parse_rate_limit(self) -> tuple[int | None, int | None]:
+        """Parse rate limit from RateLimit headers."""
+        limit = None
+        remaining = None
+
+        if (policy := self._last_headers.get("RateLimit-Policy", "")) and (
+            match := re.search(r"quota=(\d+)", policy)
+        ):
+            limit = int(match[1])
+
+        if (rl := self._last_headers.get("RateLimit", "")) and (
+            match := re.search(r"remaining=(\d+)", rl)
+        ):
+            remaining = int(match[1])
+
+        return limit, remaining
 
     async def __aenter__(self) -> Self:
         """Async enter."""

--- a/src/tadoasync/tadoasync.py
+++ b/src/tadoasync/tadoasync.py
@@ -847,20 +847,17 @@ class Tado:  # pylint: disable=too-many-instance-attributes
 
     def _parse_rate_limit(self) -> tuple[int | None, int | None]:
         """Parse rate limit from RateLimit headers."""
-        limit = None
-        remaining = None
+    def extract(pattern: str, value: str) -> int | None:
+        match = re.search(pattern, value)
+        return int(match.group(1)) if match else None
 
-        if (policy := self._last_headers.get("RateLimit-Policy", "")) and (
-            match := re.search(r"quota=(\d+)", policy)
-        ):
-            limit = int(match[1])
+    policy = self._last_headers.get("RateLimit-Policy", "")
+    rl = self._last_headers.get("RateLimit", "")
 
-        if (rl := self._last_headers.get("RateLimit", "")) and (
-            match := re.search(r"remaining=(\d+)", rl)
-        ):
-            remaining = int(match[1])
+    limit = extract(r"quota=(\d+)", policy)
+    remaining = extract(r"remaining=(\d+)", rl)
 
-        return limit, remaining
+    return limit, remaining
 
     async def __aenter__(self) -> Self:
         """Async enter."""


### PR DESCRIPTION
Essential improvements for production use:

Rate Limit Support (NEW):
- Add: Store response headers from API calls
- Add: Parse RateLimit headers per IETF draft spec
- Add: rate_limit property returning (limit, remaining) tuple
- Add: last_headers property for debugging
- Change: Use context manager to access headers before consuming body

Public API (NEW - enables extensions):
- Add: session property (get aiohttp ClientSession)
- Add: home_id property (get home ID)
- Add: access_token property (get OAuth token)
- Add: refresh_auth() public method (refresh token)

Model Fixes:
- Fix: ZoneState null nextTimeBlock handling (API sometimes returns null)

Breaking Changes: None (only additions and one critical bug fix)

All changes are backward compatible. Existing code works unchanged.

Enables Home Assistant integrations to:
- Track API quota usage (rate_limit property)
- Build extensions without private attribute access (public API)
- Handle edge cases in API responses (ZoneState fix)